### PR TITLE
Add LVGL LCD dashboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Choose your operation mode based on:
   - Device control interface
   - Event logging system
   - BLE-based secure communication
+  - Optional LVGL dashboard for Waveshare ESP32-S3 Touch LCD 5/5B with live WiFi/BLE metrics
 
 ## 💻 Hardware
 
@@ -158,6 +159,7 @@ Sneak32 has been extensively tested with the **ESP32-C3** board, a low-cost RISC
 - ✅ ESP32 (WROOM-32*/MINI-1/PICO-D4): Full support
 - ✅ ESP32-S3: Full support (recommended for high performance & data capacity)
 - ✅ ESP32-C3: Full support (recommended for low power consumption)
+- ✅ Waveshare ESP32-S3 Touch LCD 5/5B: Integrated LVGL dashboard via `waveshare-esp32-s3-touch-lcd-5b` PlatformIO environment
 - ❌ ESP32-S2: Not supported (no BLE)
 - ❌ ESP32-H2: Not supported (no WiFi)
 - ❌ ESP32-C6: Not supported (no Arduino-PlatformIO framework support yet)
@@ -224,6 +226,7 @@ Choose based on your specific needs:
 
    ```bash
    pio run -e esp32-c3-supermini --upload-port /dev/cu.usbmodem101 -t upload
+   pio run -e waveshare-esp32-s3-touch-lcd-5b -t upload  # build LVGL dashboard for Waveshare panels
    ```
 
    With PlatformIO Visual Studio Code Extension, use the "Upload" button.

--- a/include/lv_conf.h
+++ b/include/lv_conf.h
@@ -1,0 +1,784 @@
+/**
+ * @file lv_conf.h
+ * Configuration file for v8.4.0
+ */
+
+/*
+ * Copy this file as `lv_conf.h`
+ * 1. simply next to the `lvgl` folder
+ * 2. or any other places and
+ *    - define `LV_CONF_INCLUDE_SIMPLE`
+ *    - add the path as include path
+ */
+
+/* clang-format off */
+#if 1 /*Set it to "1" to enable content*/
+
+#ifndef LV_CONF_H
+#define LV_CONF_H
+
+#include <stdint.h>
+
+/*====================
+   COLOR SETTINGS
+ *====================*/
+
+/*Color depth: 1 (1 byte per pixel), 8 (RGB332), 16 (RGB565), 32 (ARGB8888)*/
+#define LV_COLOR_DEPTH 16
+
+/*Swap the 2 bytes of RGB565 color. Useful if the display has an 8-bit interface (e.g. SPI)*/
+#define LV_COLOR_16_SWAP 0
+
+/*Enable features to draw on transparent background.
+ *It's required if opa, and transform_* style properties are used.
+ *Can be also used if the UI is above another layer, e.g. an OSD menu or video player.*/
+#define LV_COLOR_SCREEN_TRANSP 1
+
+/* Adjust color mix functions rounding. GPUs might calculate color mix (blending) differently.
+ * 0: round down, 64: round up from x.75, 128: round up from half, 192: round up from x.25, 254: round up */
+#define LV_COLOR_MIX_ROUND_OFS 0
+
+/*Images pixels with this color will not be drawn if they are chroma keyed)*/
+#define LV_COLOR_CHROMA_KEY lv_color_hex(0x00ff00)         /*pure green*/
+
+/*=========================
+   MEMORY SETTINGS
+ *=========================*/
+
+/*1: use custom malloc/free, 0: use the built-in `lv_mem_alloc()` and `lv_mem_free()`*/
+#define LV_MEM_CUSTOM 1
+#if LV_MEM_CUSTOM == 0
+    /*Size of the memory available for `lv_mem_alloc()` in bytes (>= 2kB)*/
+    #define LV_MEM_SIZE (48U * 1024U)          /*[bytes]*/
+
+    /*Set an address for the memory pool instead of allocating it as a normal array. Can be in external SRAM too.*/
+    #define LV_MEM_ADR 0     /*0: unused*/
+    /*Instead of an address give a memory allocator that will be called to get a memory pool for LVGL. E.g. my_malloc*/
+    #if LV_MEM_ADR == 0
+        #undef LV_MEM_POOL_INCLUDE
+        #undef LV_MEM_POOL_ALLOC
+    #endif
+
+#else       /*LV_MEM_CUSTOM*/
+    #define LV_MEM_CUSTOM_INCLUDE <stdlib.h>   /*Header for the dynamic memory function*/
+    #define LV_MEM_CUSTOM_ALLOC   malloc
+    #define LV_MEM_CUSTOM_FREE    free
+    #define LV_MEM_CUSTOM_REALLOC realloc
+#endif     /*LV_MEM_CUSTOM*/
+
+/*Number of the intermediate memory buffer used during rendering and other internal processing mechanisms.
+ *You will see an error log message if there wasn't enough buffers. */
+#define LV_MEM_BUF_MAX_NUM 16
+
+/*Use the standard `memcpy` and `memset` instead of LVGL's own functions. (Might or might not be faster).*/
+#define LV_MEMCPY_MEMSET_STD 0
+
+/*====================
+   HAL SETTINGS
+ *====================*/
+
+/*Default display refresh period. LVG will redraw changed areas with this period time*/
+#define LV_DISP_DEF_REFR_PERIOD 30      /*[ms]*/
+
+/*Input device read period in milliseconds*/
+#define LV_INDEV_DEF_READ_PERIOD 30     /*[ms]*/
+
+/*Use a custom tick source that tells the elapsed time in milliseconds.
+ *It removes the need to manually update the tick with `lv_tick_inc()`)*/
+#define LV_TICK_CUSTOM 0
+#if LV_TICK_CUSTOM
+    #define LV_TICK_CUSTOM_INCLUDE "Arduino.h"         /*Header for the system time function*/
+    #define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())    /*Expression evaluating to current system time in ms*/
+    /*If using lvgl as ESP32 component*/
+    // #define LV_TICK_CUSTOM_INCLUDE "esp_timer.h"
+    // #define LV_TICK_CUSTOM_SYS_TIME_EXPR ((esp_timer_get_time() / 1000LL))
+#endif   /*LV_TICK_CUSTOM*/
+
+/*Default Dot Per Inch. Used to initialize default sizes such as widgets sized, style paddings.
+ *(Not so important, you can adjust it to modify default sizes and spaces)*/
+#define LV_DPI_DEF 130     /*[px/inch]*/
+
+/*=======================
+ * FEATURE CONFIGURATION
+ *=======================*/
+
+/*-------------
+ * Drawing
+ *-----------*/
+
+/*Enable complex draw engine.
+ *Required to draw shadow, gradient, rounded corners, circles, arc, skew lines, image transformations or any masks*/
+#define LV_DRAW_COMPLEX 1
+#if LV_DRAW_COMPLEX != 0
+
+    /*Allow buffering some shadow calculation.
+    *LV_SHADOW_CACHE_SIZE is the max. shadow size to buffer, where shadow size is `shadow_width + radius`
+    *Caching has LV_SHADOW_CACHE_SIZE^2 RAM cost*/
+    #define LV_SHADOW_CACHE_SIZE 0
+
+    /* Set number of maximally cached circle data.
+    * The circumference of 1/4 circle are saved for anti-aliasing
+    * radius * 4 bytes are used per circle (the most often used radiuses are saved)
+    * 0: to disable caching */
+    #define LV_CIRCLE_CACHE_SIZE 4
+#endif /*LV_DRAW_COMPLEX*/
+
+/**
+ * "Simple layers" are used when a widget has `style_opa < 255` to buffer the widget into a layer
+ * and blend it as an image with the given opacity.
+ * Note that `bg_opa`, `text_opa` etc don't require buffering into layer)
+ * The widget can be buffered in smaller chunks to avoid using large buffers.
+ *
+ * - LV_LAYER_SIMPLE_BUF_SIZE: [bytes] the optimal target buffer size. LVGL will try to allocate it
+ * - LV_LAYER_SIMPLE_FALLBACK_BUF_SIZE: [bytes]  used if `LV_LAYER_SIMPLE_BUF_SIZE` couldn't be allocated.
+ *
+ * Both buffer sizes are in bytes.
+ * "Transformed layers" (where transform_angle/zoom properties are used) use larger buffers
+ * and can't be drawn in chunks. So these settings affects only widgets with opacity.
+ */
+#define LV_LAYER_SIMPLE_BUF_SIZE          (24 * 1024)
+#define LV_LAYER_SIMPLE_FALLBACK_BUF_SIZE (3 * 1024)
+
+/*Default image cache size. Image caching keeps the images opened.
+ *If only the built-in image formats are used there is no real advantage of caching. (I.e. if no new image decoder is added)
+ *With complex image decoders (e.g. PNG or JPG) caching can save the continuous open/decode of images.
+ *However the opened images might consume additional RAM.
+ *0: to disable caching*/
+#define LV_IMG_CACHE_DEF_SIZE 0
+
+/*Number of stops allowed per gradient. Increase this to allow more stops.
+ *This adds (sizeof(lv_color_t) + 1) bytes per additional stop*/
+#define LV_GRADIENT_MAX_STOPS 2
+
+/*Default gradient buffer size.
+ *When LVGL calculates the gradient "maps" it can save them into a cache to avoid calculating them again.
+ *LV_GRAD_CACHE_DEF_SIZE sets the size of this cache in bytes.
+ *If the cache is too small the map will be allocated only while it's required for the drawing.
+ *0 mean no caching.*/
+#define LV_GRAD_CACHE_DEF_SIZE 0
+
+/*Allow dithering the gradients (to achieve visual smooth color gradients on limited color depth display)
+ *LV_DITHER_GRADIENT implies allocating one or two more lines of the object's rendering surface
+ *The increase in memory consumption is (32 bits * object width) plus 24 bits * object width if using error diffusion */
+#define LV_DITHER_GRADIENT 0
+#if LV_DITHER_GRADIENT
+    /*Add support for error diffusion dithering.
+     *Error diffusion dithering gets a much better visual result, but implies more CPU consumption and memory when drawing.
+     *The increase in memory consumption is (24 bits * object's width)*/
+    #define LV_DITHER_ERROR_DIFFUSION 0
+#endif
+
+/*Maximum buffer size to allocate for rotation.
+ *Only used if software rotation is enabled in the display driver.*/
+#define LV_DISP_ROT_MAX_BUF (10*1024)
+
+/*-------------
+ * GPU
+ *-----------*/
+
+/*Use Arm's 2D acceleration library Arm-2D */
+#define LV_USE_GPU_ARM2D 0
+
+/*Use STM32's DMA2D (aka Chrom Art) GPU*/
+#define LV_USE_GPU_STM32_DMA2D 0
+#if LV_USE_GPU_STM32_DMA2D
+    /*Must be defined to include path of CMSIS header of target processor
+    e.g. "stm32f7xx.h" or "stm32f4xx.h"*/
+    #define LV_GPU_DMA2D_CMSIS_INCLUDE
+#endif
+
+/*Enable RA6M3 G2D GPU*/
+#define LV_USE_GPU_RA6M3_G2D 0
+#if LV_USE_GPU_RA6M3_G2D
+    /*include path of target processor
+    e.g. "hal_data.h"*/
+    #define LV_GPU_RA6M3_G2D_INCLUDE "hal_data.h"
+#endif
+
+/*Use SWM341's DMA2D GPU*/
+#define LV_USE_GPU_SWM341_DMA2D 0
+#if LV_USE_GPU_SWM341_DMA2D
+    #define LV_GPU_SWM341_DMA2D_INCLUDE "SWM341.h"
+#endif
+
+/*Use NXP's PXP GPU iMX RTxxx platforms*/
+#define LV_USE_GPU_NXP_PXP 0
+#if LV_USE_GPU_NXP_PXP
+    /*1: Add default bare metal and FreeRTOS interrupt handling routines for PXP (lv_gpu_nxp_pxp_osa.c)
+    *   and call lv_gpu_nxp_pxp_init() automatically during lv_init(). Note that symbol SDK_OS_FREE_RTOS
+    *   has to be defined in order to use FreeRTOS OSA, otherwise bare-metal implementation is selected.
+    *0: lv_gpu_nxp_pxp_init() has to be called manually before lv_init()
+    */
+    #define LV_USE_GPU_NXP_PXP_AUTO_INIT 0
+#endif
+
+/*Use NXP's VG-Lite GPU iMX RTxxx platforms*/
+#define LV_USE_GPU_NXP_VG_LITE 0
+
+/*Use SDL renderer API*/
+#define LV_USE_GPU_SDL 0
+#if LV_USE_GPU_SDL
+    #define LV_GPU_SDL_INCLUDE_PATH <SDL2/SDL.h>
+    /*Texture cache size, 8MB by default*/
+    #define LV_GPU_SDL_LRU_SIZE (1024 * 1024 * 8)
+    /*Custom blend mode for mask drawing, disable if you need to link with older SDL2 lib*/
+    #define LV_GPU_SDL_CUSTOM_BLEND_MODE (SDL_VERSION_ATLEAST(2, 0, 6))
+#endif
+
+/*-------------
+ * Logging
+ *-----------*/
+
+/*Enable the log module*/
+#define LV_USE_LOG 1
+#if LV_USE_LOG
+
+    /*How important log should be added:
+    *LV_LOG_LEVEL_TRACE       A lot of logs to give detailed information
+    *LV_LOG_LEVEL_INFO        Log important events
+    *LV_LOG_LEVEL_WARN        Log if something unwanted happened but didn't cause a problem
+    *LV_LOG_LEVEL_ERROR       Only critical issue, when the system may fail
+    *LV_LOG_LEVEL_USER        Only logs added by the user
+    *LV_LOG_LEVEL_NONE        Do not log anything*/
+    #define LV_LOG_LEVEL LV_LOG_LEVEL_WARN
+
+    /*1: Print the log with 'printf';
+    *0: User need to register a callback with `lv_log_register_print_cb()`*/
+    #define LV_LOG_PRINTF 1
+
+    /*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/
+    #define LV_LOG_TRACE_MEM        1
+    #define LV_LOG_TRACE_TIMER      1
+    #define LV_LOG_TRACE_INDEV      1
+    #define LV_LOG_TRACE_DISP_REFR  1
+    #define LV_LOG_TRACE_EVENT      1
+    #define LV_LOG_TRACE_OBJ_CREATE 1
+    #define LV_LOG_TRACE_LAYOUT     1
+    #define LV_LOG_TRACE_ANIM       1
+
+#endif  /*LV_USE_LOG*/
+
+/*-------------
+ * Asserts
+ *-----------*/
+
+/*Enable asserts if an operation is failed or an invalid data is found.
+ *If LV_USE_LOG is enabled an error message will be printed on failure*/
+#define LV_USE_ASSERT_NULL          1   /*Check if the parameter is NULL. (Very fast, recommended)*/
+#define LV_USE_ASSERT_MALLOC        1   /*Checks is the memory is successfully allocated or no. (Very fast, recommended)*/
+#define LV_USE_ASSERT_STYLE         0   /*Check if the styles are properly initialized. (Very fast, recommended)*/
+#define LV_USE_ASSERT_MEM_INTEGRITY 0   /*Check the integrity of `lv_mem` after critical operations. (Slow)*/
+#define LV_USE_ASSERT_OBJ           0   /*Check the object's type and existence (e.g. not deleted). (Slow)*/
+
+/*Add a custom handler when assert happens e.g. to restart the MCU*/
+#define LV_ASSERT_HANDLER_INCLUDE <stdint.h>
+#define LV_ASSERT_HANDLER while(1);   /*Halt by default*/
+
+/*-------------
+ * Others
+ *-----------*/
+
+/*1: Show CPU usage and FPS count*/
+#define LV_USE_PERF_MONITOR 1
+#if LV_USE_PERF_MONITOR
+    #define LV_USE_PERF_MONITOR_POS LV_ALIGN_BOTTOM_RIGHT
+#endif
+
+/*1: Show the used memory and the memory fragmentation
+ * Requires LV_MEM_CUSTOM = 0*/
+#define LV_USE_MEM_MONITOR 0
+#if LV_USE_MEM_MONITOR
+    #define LV_USE_MEM_MONITOR_POS LV_ALIGN_BOTTOM_LEFT
+#endif
+
+/*1: Draw random colored rectangles over the redrawn areas*/
+#define LV_USE_REFR_DEBUG 0
+
+/*Change the built in (v)snprintf functions*/
+#define LV_SPRINTF_CUSTOM 0
+#if LV_SPRINTF_CUSTOM
+    #define LV_SPRINTF_INCLUDE <stdio.h>
+    #define lv_snprintf  snprintf
+    #define lv_vsnprintf vsnprintf
+#else   /*LV_SPRINTF_CUSTOM*/
+    #define LV_SPRINTF_USE_FLOAT 0
+#endif  /*LV_SPRINTF_CUSTOM*/
+
+#define LV_USE_USER_DATA 1
+
+/*Garbage Collector settings
+ *Used if lvgl is bound to higher level language and the memory is managed by that language*/
+#define LV_ENABLE_GC 0
+#if LV_ENABLE_GC != 0
+    #define LV_GC_INCLUDE "gc.h"                           /*Include Garbage Collector related things*/
+#endif /*LV_ENABLE_GC*/
+
+/*=====================
+ *  COMPILER SETTINGS
+ *====================*/
+
+/*For big endian systems set to 1*/
+#define LV_BIG_ENDIAN_SYSTEM 0
+
+/*Define a custom attribute to `lv_tick_inc` function*/
+#define LV_ATTRIBUTE_TICK_INC
+
+/*Define a custom attribute to `lv_timer_handler` function*/
+#define LV_ATTRIBUTE_TIMER_HANDLER
+
+/*Define a custom attribute to `lv_disp_flush_ready` function*/
+#define LV_ATTRIBUTE_FLUSH_READY
+
+/*Required alignment size for buffers*/
+#define LV_ATTRIBUTE_MEM_ALIGN_SIZE 1
+
+/*Will be added where memories needs to be aligned (with -Os data might not be aligned to boundary by default).
+ * E.g. __attribute__((aligned(4)))*/
+#define LV_ATTRIBUTE_MEM_ALIGN
+
+/*Attribute to mark large constant arrays for example font's bitmaps*/
+#define LV_ATTRIBUTE_LARGE_CONST
+
+/*Compiler prefix for a big array declaration in RAM*/
+#define LV_ATTRIBUTE_LARGE_RAM_ARRAY
+
+/*Place performance critical functions into a faster memory (e.g RAM)*/
+#define LV_ATTRIBUTE_FAST_MEM
+
+/*Prefix variables that are used in GPU accelerated operations, often these need to be placed in RAM sections that are DMA accessible*/
+#define LV_ATTRIBUTE_DMA
+
+/*Export integer constant to binding. This macro is used with constants in the form of LV_<CONST> that
+ *should also appear on LVGL binding API such as Micropython.*/
+#define LV_EXPORT_CONST_INT(int_value) struct _silence_gcc_warning /*The default value just prevents GCC warning*/
+
+/*Extend the default -32k..32k coordinate range to -4M..4M by using int32_t for coordinates instead of int16_t*/
+#define LV_USE_LARGE_COORD 0
+
+/*==================
+ *   FONT USAGE
+ *===================*/
+
+/*Montserrat fonts with ASCII range and some symbols using bpp = 4
+ *https://fonts.google.com/specimen/Montserrat */
+#define LV_FONT_MONTSERRAT_8 0
+#define LV_FONT_MONTSERRAT_10 0
+#define LV_FONT_MONTSERRAT_12 0
+#define LV_FONT_MONTSERRAT_14 1
+#define LV_FONT_MONTSERRAT_16 0
+#define LV_FONT_MONTSERRAT_18 0
+#define LV_FONT_MONTSERRAT_20 1
+#define LV_FONT_MONTSERRAT_22 0
+#define LV_FONT_MONTSERRAT_24 0
+#define LV_FONT_MONTSERRAT_26 0
+#define LV_FONT_MONTSERRAT_28 1
+#define LV_FONT_MONTSERRAT_30 0
+#define LV_FONT_MONTSERRAT_32 0
+#define LV_FONT_MONTSERRAT_34 0
+#define LV_FONT_MONTSERRAT_36 0
+#define LV_FONT_MONTSERRAT_38 0
+#define LV_FONT_MONTSERRAT_40 0
+#define LV_FONT_MONTSERRAT_42 0
+#define LV_FONT_MONTSERRAT_44 0
+#define LV_FONT_MONTSERRAT_46 0
+#define LV_FONT_MONTSERRAT_48 0
+
+/*Demonstrate special features*/
+#define LV_FONT_MONTSERRAT_12_SUBPX      0
+#define LV_FONT_MONTSERRAT_28_COMPRESSED 0  /*bpp = 3*/
+#define LV_FONT_DEJAVU_16_PERSIAN_HEBREW 0  /*Hebrew, Arabic, Persian letters and all their forms*/
+#define LV_FONT_SIMSUN_16_CJK            0  /*1000 most common CJK radicals*/
+
+/*Pixel perfect monospace fonts*/
+#define LV_FONT_UNSCII_8  0
+#define LV_FONT_UNSCII_16 0
+
+/*Optionally declare custom fonts here.
+ *You can use these fonts as default font too and they will be available globally.
+ *E.g. #define LV_FONT_CUSTOM_DECLARE   LV_FONT_DECLARE(my_font_1) LV_FONT_DECLARE(my_font_2)*/
+#define LV_FONT_CUSTOM_DECLARE
+
+/*Always set a default font*/
+#define LV_FONT_DEFAULT &lv_font_montserrat_20
+
+/*Enable handling large font and/or fonts with a lot of characters.
+ *The limit depends on the font size, font face and bpp.
+ *Compiler error will be triggered if a font needs it.*/
+#define LV_FONT_FMT_TXT_LARGE 0
+
+/*Enables/disables support for compressed fonts.*/
+#define LV_USE_FONT_COMPRESSED 0
+
+/*Enable subpixel rendering*/
+#define LV_USE_FONT_SUBPX 0
+#if LV_USE_FONT_SUBPX
+    /*Set the pixel order of the display. Physical order of RGB channels. Doesn't matter with "normal" fonts.*/
+    #define LV_FONT_SUBPX_BGR 0  /*0: RGB; 1:BGR order*/
+#endif
+
+/*Enable drawing placeholders when glyph dsc is not found*/
+#define LV_USE_FONT_PLACEHOLDER 1
+
+/*=================
+ *  TEXT SETTINGS
+ *=================*/
+
+/**
+ * Select a character encoding for strings.
+ * Your IDE or editor should have the same character encoding
+ * - LV_TXT_ENC_UTF8
+ * - LV_TXT_ENC_ASCII
+ */
+#define LV_TXT_ENC LV_TXT_ENC_UTF8
+
+/*Can break (wrap) texts on these chars*/
+#define LV_TXT_BREAK_CHARS " ,.;:-_"
+
+/*If a word is at least this long, will break wherever "prettiest"
+ *To disable, set to a value <= 0*/
+#define LV_TXT_LINE_BREAK_LONG_LEN 0
+
+/*Minimum number of characters in a long word to put on a line before a break.
+ *Depends on LV_TXT_LINE_BREAK_LONG_LEN.*/
+#define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN 3
+
+/*Minimum number of characters in a long word to put on a line after a break.
+ *Depends on LV_TXT_LINE_BREAK_LONG_LEN.*/
+#define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 3
+
+/*The control character to use for signalling text recoloring.*/
+#define LV_TXT_COLOR_CMD "#"
+
+/*Support bidirectional texts. Allows mixing Left-to-Right and Right-to-Left texts.
+ *The direction will be processed according to the Unicode Bidirectional Algorithm:
+ *https://www.w3.org/International/articles/inline-bidi-markup/uba-basics */
+#define LV_USE_BIDI 0
+#if LV_USE_BIDI
+    /*Set the default direction. Supported values:
+    *`LV_BASE_DIR_LTR` Left-to-Right
+    *`LV_BASE_DIR_RTL` Right-to-Left
+    *`LV_BASE_DIR_AUTO` detect texts base direction*/
+    #define LV_BIDI_BASE_DIR_DEF LV_BASE_DIR_AUTO
+#endif
+
+/*Enable Arabic/Persian processing
+ *In these languages characters should be replaced with an other form based on their position in the text*/
+#define LV_USE_ARABIC_PERSIAN_CHARS 0
+
+/*==================
+ *  WIDGET USAGE
+ *================*/
+
+/*Documentation of the widgets: https://docs.lvgl.io/latest/en/html/widgets/index.html */
+
+#define LV_USE_ARC        1
+
+#define LV_USE_BAR        1
+
+#define LV_USE_BTN        1
+
+#define LV_USE_BTNMATRIX  1
+
+#define LV_USE_CANVAS     1
+
+#define LV_USE_CHECKBOX   1
+
+#define LV_USE_DROPDOWN   1   /*Requires: lv_label*/
+
+#define LV_USE_IMG        1   /*Requires: lv_label*/
+
+#define LV_USE_LABEL      1
+#if LV_USE_LABEL
+    #define LV_LABEL_TEXT_SELECTION 1 /*Enable selecting text of the label*/
+    #define LV_LABEL_LONG_TXT_HINT 1  /*Store some extra info in labels to speed up drawing of very long texts*/
+#endif
+
+#define LV_USE_LINE       1
+
+#define LV_USE_ROLLER     1   /*Requires: lv_label*/
+#if LV_USE_ROLLER
+    #define LV_ROLLER_INF_PAGES 7 /*Number of extra "pages" when the roller is infinite*/
+#endif
+
+#define LV_USE_SLIDER     1   /*Requires: lv_bar*/
+
+#define LV_USE_SWITCH     1
+
+#define LV_USE_TEXTAREA   1   /*Requires: lv_label*/
+#if LV_USE_TEXTAREA != 0
+    #define LV_TEXTAREA_DEF_PWD_SHOW_TIME 1500    /*ms*/
+#endif
+
+#define LV_USE_TABLE      1
+
+/*==================
+ * EXTRA COMPONENTS
+ *==================*/
+
+/*-----------
+ * Widgets
+ *----------*/
+#define LV_USE_ANIMIMG    1
+
+#define LV_USE_CALENDAR   1
+#if LV_USE_CALENDAR
+    #define LV_CALENDAR_WEEK_STARTS_MONDAY 0
+    #if LV_CALENDAR_WEEK_STARTS_MONDAY
+        #define LV_CALENDAR_DEFAULT_DAY_NAMES {"Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"}
+    #else
+        #define LV_CALENDAR_DEFAULT_DAY_NAMES {"Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"}
+    #endif
+
+    #define LV_CALENDAR_DEFAULT_MONTH_NAMES {"January", "February", "March",  "April", "May",  "June", "July", "August", "September", "October", "November", "December"}
+    #define LV_USE_CALENDAR_HEADER_ARROW 1
+    #define LV_USE_CALENDAR_HEADER_DROPDOWN 1
+#endif  /*LV_USE_CALENDAR*/
+
+#define LV_USE_CHART      1
+
+#define LV_USE_COLORWHEEL 1
+
+#define LV_USE_IMGBTN     1
+
+#define LV_USE_KEYBOARD   1
+
+#define LV_USE_LED        1
+
+#define LV_USE_LIST       1
+
+#define LV_USE_MENU       1
+
+#define LV_USE_METER      1
+
+#define LV_USE_MSGBOX     1
+
+#define LV_USE_SPAN       1
+#if LV_USE_SPAN
+    /*A line text can contain maximum num of span descriptor */
+    #define LV_SPAN_SNIPPET_STACK_SIZE 64
+#endif
+
+#define LV_USE_SPINBOX    1
+
+#define LV_USE_SPINNER    1
+
+#define LV_USE_TABVIEW    1
+
+#define LV_USE_TILEVIEW   1
+
+#define LV_USE_WIN        1
+
+/*-----------
+ * Themes
+ *----------*/
+
+/*A simple, impressive and very complete theme*/
+#define LV_USE_THEME_DEFAULT 1
+#if LV_USE_THEME_DEFAULT
+
+    /*0: Light mode; 1: Dark mode*/
+    #define LV_THEME_DEFAULT_DARK 0
+
+    /*1: Enable grow on press*/
+    #define LV_THEME_DEFAULT_GROW 1
+
+    /*Default transition time in [ms]*/
+    #define LV_THEME_DEFAULT_TRANSITION_TIME 80
+#endif /*LV_USE_THEME_DEFAULT*/
+
+/*A very simple theme that is a good starting point for a custom theme*/
+#define LV_USE_THEME_BASIC 1
+
+/*A theme designed for monochrome displays*/
+#define LV_USE_THEME_MONO 1
+
+/*-----------
+ * Layouts
+ *----------*/
+
+/*A layout similar to Flexbox in CSS.*/
+#define LV_USE_FLEX 1
+
+/*A layout similar to Grid in CSS.*/
+#define LV_USE_GRID 1
+
+/*---------------------
+ * 3rd party libraries
+ *--------------------*/
+
+/*File system interfaces for common APIs */
+
+/*API for fopen, fread, etc*/
+#define LV_USE_FS_STDIO 0
+#if LV_USE_FS_STDIO
+    #define LV_FS_STDIO_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_STDIO_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
+    #define LV_FS_STDIO_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for open, read, etc*/
+#define LV_USE_FS_POSIX 0
+#if LV_USE_FS_POSIX
+    #define LV_FS_POSIX_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_POSIX_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
+    #define LV_FS_POSIX_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for CreateFile, ReadFile, etc*/
+#define LV_USE_FS_WIN32 0
+#if LV_USE_FS_WIN32
+    #define LV_FS_WIN32_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_WIN32_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
+    #define LV_FS_WIN32_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for FATFS (needs to be added separately). Uses f_open, f_read, etc*/
+#define LV_USE_FS_FATFS 0
+#if LV_USE_FS_FATFS
+    #define LV_FS_FATFS_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_FATFS_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for LittleFS (library needs to be added separately). Uses lfs_file_open, lfs_file_read, etc*/
+#define LV_USE_FS_LITTLEFS 0
+#if LV_USE_FS_LITTLEFS
+    #define LV_FS_LITTLEFS_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_LITTLEFS_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*PNG decoder library*/
+#define LV_USE_PNG 0
+
+/*BMP decoder library*/
+#define LV_USE_BMP 0
+
+/* JPG + split JPG decoder library.
+ * Split JPG is a custom format optimized for embedded systems. */
+#define LV_USE_SJPG 0
+
+/*GIF decoder library*/
+#define LV_USE_GIF 0
+
+/*QR code library*/
+#define LV_USE_QRCODE 0
+
+/*FreeType library*/
+#define LV_USE_FREETYPE 0
+#if LV_USE_FREETYPE
+    /*Memory used by FreeType to cache characters [bytes] (-1: no caching)*/
+    #define LV_FREETYPE_CACHE_SIZE (16 * 1024)
+    #if LV_FREETYPE_CACHE_SIZE >= 0
+        /* 1: bitmap cache use the sbit cache, 0:bitmap cache use the image cache. */
+        /* sbit cache:it is much more memory efficient for small bitmaps(font size < 256) */
+        /* if font size >= 256, must be configured as image cache */
+        #define LV_FREETYPE_SBIT_CACHE 0
+        /* Maximum number of opened FT_Face/FT_Size objects managed by this cache instance. */
+        /* (0:use system defaults) */
+        #define LV_FREETYPE_CACHE_FT_FACES 0
+        #define LV_FREETYPE_CACHE_FT_SIZES 0
+    #endif
+#endif
+
+/*Tiny TTF library*/
+#define LV_USE_TINY_TTF 0
+#if LV_USE_TINY_TTF
+    /*Load TTF data from files*/
+    #define LV_TINY_TTF_FILE_SUPPORT 0
+#endif
+
+/*Rlottie library*/
+#define LV_USE_RLOTTIE 0
+
+/*FFmpeg library for image decoding and playing videos
+ *Supports all major image formats so do not enable other image decoder with it*/
+#define LV_USE_FFMPEG 0
+#if LV_USE_FFMPEG
+    /*Dump input information to stderr*/
+    #define LV_FFMPEG_DUMP_FORMAT 0
+#endif
+
+/*-----------
+ * Others
+ *----------*/
+
+/*1: Enable API to take snapshot for object*/
+#define LV_USE_SNAPSHOT 0
+
+/*1: Enable Monkey test*/
+#define LV_USE_MONKEY 0
+
+/*1: Enable grid navigation*/
+#define LV_USE_GRIDNAV 0
+
+/*1: Enable lv_obj fragment*/
+#define LV_USE_FRAGMENT 0
+
+/*1: Support using images as font in label or span widgets */
+#define LV_USE_IMGFONT 0
+
+/*1: Enable a published subscriber based messaging system */
+#define LV_USE_MSG 0
+
+/*1: Enable Pinyin input method*/
+/*Requires: lv_keyboard*/
+#define LV_USE_IME_PINYIN 0
+#if LV_USE_IME_PINYIN
+    /*1: Use default thesaurus*/
+    /*If you do not use the default thesaurus, be sure to use `lv_ime_pinyin` after setting the thesauruss*/
+    #define LV_IME_PINYIN_USE_DEFAULT_DICT 1
+    /*Set the maximum number of candidate panels that can be displayed*/
+    /*This needs to be adjusted according to the size of the screen*/
+    #define LV_IME_PINYIN_CAND_TEXT_NUM 6
+
+    /*Use 9 key input(k9)*/
+    #define LV_IME_PINYIN_USE_K9_MODE      1
+    #if LV_IME_PINYIN_USE_K9_MODE == 1
+        #define LV_IME_PINYIN_K9_CAND_TEXT_NUM 3
+    #endif // LV_IME_PINYIN_USE_K9_MODE
+#endif
+
+/*==================
+* EXAMPLES
+*==================*/
+
+/*Enable the examples to be built with the library*/
+#define LV_BUILD_EXAMPLES 1
+
+/*===================
+ * DEMO USAGE
+ ====================*/
+
+/*Show some widget. It might be required to increase `LV_MEM_SIZE` */
+#define LV_USE_DEMO_WIDGETS 1
+#if LV_USE_DEMO_WIDGETS
+#define LV_DEMO_WIDGETS_SLIDESHOW 0
+#endif
+
+/*Demonstrate the usage of encoder and keyboard*/
+#define LV_USE_DEMO_KEYPAD_AND_ENCODER 0
+
+/*Benchmark your system*/
+#define LV_USE_DEMO_BENCHMARK 1
+#if LV_USE_DEMO_BENCHMARK
+/*Use RGB565A8 images with 16 bit color depth instead of ARGB8565*/
+#define LV_DEMO_BENCHMARK_RGB565A8 0
+#endif
+
+/*Stress test for LVGL*/
+#define LV_USE_DEMO_STRESS 0
+
+/*Music player demo*/
+#define LV_USE_DEMO_MUSIC 1
+#if LV_USE_DEMO_MUSIC
+    #define LV_DEMO_MUSIC_SQUARE    0
+    #define LV_DEMO_MUSIC_LANDSCAPE 0
+    #define LV_DEMO_MUSIC_ROUND     0
+    #define LV_DEMO_MUSIC_LARGE     0
+    #define LV_DEMO_MUSIC_AUTO_PLAY 1
+#endif
+
+/*--END OF LV_CONF_H--*/
+
+#endif /*LV_CONF_H*/
+
+#endif /*End of "Content enable"*/

--- a/platformio.ini
+++ b/platformio.ini
@@ -100,3 +100,24 @@ upload_speed = 460800
 ;   framework-arduinoespressif32-libs @ https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0526c35e.zip
 ; debug_tool = esp-builtin
 
+[env:waveshare-esp32-s3-touch-lcd-5b]
+board = esp32-s3-devkitc-1
+framework = arduino
+upload_speed = 921600
+monitor_speed = 115200
+board_build.flash_size = 16MB
+board_build.psram = enabled
+build_flags =
+  -DENABLE_DISPLAY=1
+  -DESP_PANEL_BOARD_DEFAULT_USE_SUPPORTED=1
+  -DBOARD_WAVESHARE_ESP32_S3_TOUCH_LCD_5_B
+  -DLV_CONF_INCLUDE_SIMPLE
+  -DLV_LVGL_H_INCLUDE_SIMPLE
+  -DLV_COLOR_16_SWAP=0
+  -DBOARD_HAS_PSRAM
+lib_deps =
+  ${env.lib_deps}
+  https://github.com/lvgl/lvgl.git#v8.3.11
+  https://github.com/esp-arduino-libs/ESP32_Display_Panel.git#v1.2.0
+  https://github.com/esp-arduino-libs/ESP32_IO_Expander.git#v1.1.0
+  https://github.com/esp-arduino-libs/esp-lib-utils.git#v0.2.0

--- a/src/display/DisplayManager.cpp
+++ b/src/display/DisplayManager.cpp
@@ -1,0 +1,323 @@
+#include "DisplayManager.h"
+
+#ifdef ENABLE_DISPLAY
+
+#include <algorithm>
+#include <cstring>
+#include <utility>
+
+#include <Arduino.h>
+#include <esp_heap_caps.h>
+#include <esp_log.h>
+#include <lvgl.h>
+
+#include "ESP_Panel_Library.h"
+
+namespace
+{
+constexpr const char *kTag = "DisplayManager";
+std::string makeSafeString(const char *value)
+{
+    if (!value)
+    {
+        return {};
+    }
+    return std::string(value, strnlen(value, 64));
+}
+
+} // namespace
+
+DisplayManager::DisplayManager() = default;
+
+void DisplayManager::begin()
+{
+    if (initialized_)
+    {
+        return;
+    }
+
+    if (!board_.init())
+    {
+        ESP_LOGE(kTag, "Failed to initialise display board");
+        return;
+    }
+
+    if (!board_.begin())
+    {
+        ESP_LOGE(kTag, "Failed to start display board");
+        return;
+    }
+
+    lcd_ = board_.getLCD();
+    touch_ = board_.getTouch();
+
+    if (!lcd_)
+    {
+        ESP_LOGE(kTag, "LCD driver not available");
+        return;
+    }
+
+    lv_init();
+
+    const int width = std::max(1, lcd_->getFrameWidth());
+    const int height = std::max(1, lcd_->getFrameHeight());
+
+    bufferSizeBytes_ = width * kBufferLines * sizeof(lv_color_t);
+    drawBuffer1_ = static_cast<lv_color_t *>(heap_caps_malloc(bufferSizeBytes_, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+    if (!drawBuffer1_)
+    {
+        drawBuffer1_ = static_cast<lv_color_t *>(heap_caps_malloc(bufferSizeBytes_, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
+    }
+    drawBuffer2_ = static_cast<lv_color_t *>(heap_caps_malloc(bufferSizeBytes_, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+
+    if (!drawBuffer1_)
+    {
+        ESP_LOGE(kTag, "Failed to allocate LVGL draw buffer");
+        return;
+    }
+
+    display_ = lv_display_create(width, height);
+    lv_display_set_flush_cb(display_, flushCallback);
+    lv_display_set_user_data(display_, this);
+    lv_display_set_buffers(display_, drawBuffer1_, drawBuffer2_, bufferSizeBytes_, LV_DISPLAY_RENDER_MODE_PARTIAL);
+
+    if (touch_)
+    {
+        inputDevice_ = lv_indev_create();
+        lv_indev_set_type(inputDevice_, LV_INDEV_TYPE_POINTER);
+        lv_indev_set_read_cb(inputDevice_, touchReadCallback);
+        lv_indev_set_user_data(inputDevice_, this);
+    }
+
+    mutex_ = xSemaphoreCreateRecursiveMutex();
+    if (!mutex_)
+    {
+        ESP_LOGE(kTag, "Failed to create LVGL mutex");
+        return;
+    }
+
+    esp_timer_create_args_t timerArgs = {
+        .callback = &DisplayManager::tickCallback,
+        .arg = this,
+        .dispatch_method = ESP_TIMER_TASK,
+        .name = "lv_tick"
+    };
+    if (esp_timer_create(&timerArgs, &tickTimer_) != ESP_OK)
+    {
+        ESP_LOGE(kTag, "Failed to create LVGL tick timer");
+        return;
+    }
+    esp_timer_start_periodic(tickTimer_, kTickPeriodMs * 1000ULL);
+
+    BaseType_t res = xTaskCreatePinnedToCore(lvglTask, "lvgl", 4096, this, 2, &taskHandle_, 1);
+    if (res != pdPASS)
+    {
+        ESP_LOGE(kTag, "Failed to create LVGL task");
+        return;
+    }
+
+    initialized_ = true;
+}
+
+void DisplayManager::loop()
+{
+    // No-op: LVGL runs in its own task
+}
+
+void DisplayManager::setDeviceConnected(bool connected)
+{
+    deviceConnected_ = connected;
+}
+
+void DisplayManager::refresh(const WifiNetworkList &networks,
+                             const WifiDeviceList &stations,
+                             const BLEDeviceList &bleDevices,
+                             const AppPreferencesData &prefs,
+                             int currentChannel,
+                             bool detectionAlarm,
+                             const std::string &detectionTarget)
+{
+    if (!initialized_)
+    {
+        return;
+    }
+
+    const uint32_t now = millis();
+    if (now - lastRefreshMs_ < kRefreshIntervalMs && lastRefreshMs_ != 0)
+    {
+        return;
+    }
+    lastRefreshMs_ = now;
+
+
+    constexpr std::size_t kMaxRows = 8;
+    auto wifiNetworks = networks.getClonedList();
+    auto wifiStations = stations.getClonedList();
+    auto bleList = bleDevices.getClonedList();
+
+    std::vector<WifiNetworkView> wifiView;
+    wifiView.reserve(wifiNetworks.size());
+    for (const auto &network : wifiNetworks)
+    {
+        WifiNetworkView view;
+        view.ssid = network.ssid.c_str();
+        view.rssi = network.rssi;
+        view.channel = network.channel;
+        view.type = network.type.c_str();
+        view.timesSeen = network.times_seen;
+        wifiView.push_back(std::move(view));
+    }
+    std::sort(wifiView.begin(), wifiView.end(), [](const WifiNetworkView &a, const WifiNetworkView &b) {
+        if (a.rssi != b.rssi)
+        {
+            return a.rssi > b.rssi;
+        }
+        return a.timesSeen > b.timesSeen;
+    });
+    if (wifiView.size() > kMaxRows)
+    {
+        wifiView.resize(kMaxRows);
+    }
+
+    std::vector<WifiDeviceView> stationView;
+    stationView.reserve(wifiStations.size());
+    for (const auto &station : wifiStations)
+    {
+        WifiDeviceView view;
+        view.mac = station.address.toString();
+        view.rssi = station.rssi;
+        view.channel = station.channel;
+        view.timesSeen = station.times_seen;
+        stationView.push_back(std::move(view));
+    }
+    std::sort(stationView.begin(), stationView.end(), [](const WifiDeviceView &a, const WifiDeviceView &b) {
+        if (a.rssi != b.rssi)
+        {
+            return a.rssi > b.rssi;
+        }
+        return a.timesSeen > b.timesSeen;
+    });
+    if (stationView.size() > kMaxRows)
+    {
+        stationView.resize(kMaxRows);
+    }
+
+    std::vector<BleDeviceView> bleView;
+    bleView.reserve(bleList.size());
+    for (const auto &device : bleList)
+    {
+        BleDeviceView view;
+        view.name = device.name.c_str();
+        view.address = device.address.toString();
+        view.isPublic = device.isPublic;
+        view.rssi = device.rssi;
+        view.timesSeen = device.times_seen;
+        bleView.push_back(std::move(view));
+    }
+    std::sort(bleView.begin(), bleView.end(), [](const BleDeviceView &a, const BleDeviceView &b) {
+        if (a.rssi != b.rssi)
+        {
+            return a.rssi > b.rssi;
+        }
+        return a.timesSeen > b.timesSeen;
+    });
+    if (bleView.size() > kMaxRows)
+    {
+        bleView.resize(kMaxRows);
+    }
+
+    DisplaySummaryInfo summary;
+    summary.wifiNetworkCount = wifiNetworks.size();
+    summary.wifiDeviceCount = wifiStations.size();
+    summary.bleDeviceCount = bleList.size();
+    summary.operationMode = prefs.operation_mode;
+    summary.passiveScan = prefs.passive_scan;
+    summary.stealthMode = prefs.stealth_mode;
+    summary.deviceConnected = deviceConnected_;
+    summary.detectionAlarm = detectionAlarm;
+    summary.currentChannel = currentChannel;
+    summary.detectionTarget = detectionTarget;
+    summary.deviceName = makeSafeString(prefs.device_name);
+    summary.lastRefreshMillis = now;
+
+    updateUI(summary, std::move(wifiView), std::move(stationView), std::move(bleView));
+}
+
+void DisplayManager::updateUI(const DisplaySummaryInfo &summary,
+                              std::vector<WifiNetworkView> networks,
+                              std::vector<WifiDeviceView> stations,
+                              std::vector<BleDeviceView> bleDevices)
+{
+    if (!mutex_)
+    {
+        return;
+    }
+
+    if (xSemaphoreTakeRecursive(mutex_, pdMS_TO_TICKS(50)) == pdTRUE)
+    {
+        ui_.update(summary, networks, stations, bleDevices);
+        xSemaphoreGiveRecursive(mutex_);
+    }
+}
+
+void DisplayManager::lvglTask(void *param)
+{
+    auto *manager = static_cast<DisplayManager *>(param);
+    while (true)
+    {
+        if (manager->mutex_ && xSemaphoreTakeRecursive(manager->mutex_, portMAX_DELAY) == pdTRUE)
+        {
+            lv_timer_handler();
+            xSemaphoreGiveRecursive(manager->mutex_);
+        }
+        vTaskDelay(pdMS_TO_TICKS(5));
+    }
+}
+
+void DisplayManager::tickCallback(void *param)
+{
+    (void)param;
+    lv_tick_inc(kTickPeriodMs);
+}
+
+void DisplayManager::flushCallback(lv_display_t *disp, const lv_area_t *area, uint8_t *pxMap)
+{
+    auto *manager = static_cast<DisplayManager *>(lv_display_get_user_data(disp));
+    if (!manager || !manager->lcd_)
+    {
+        lv_disp_flush_ready(disp);
+        return;
+    }
+
+    const int32_t w = area->x2 - area->x1 + 1;
+    const int32_t h = area->y2 - area->y1 + 1;
+    manager->lcd_->drawBitmap(area->x1, area->y1, w, h, pxMap);
+    lv_disp_flush_ready(disp);
+}
+
+void DisplayManager::touchReadCallback(lv_indev_t *indev, lv_indev_data_t *data)
+{
+    auto *manager = static_cast<DisplayManager *>(lv_indev_get_user_data(indev));
+    if (!manager || !manager->touch_)
+    {
+        data->state = LV_INDEV_STATE_REL;
+        return;
+    }
+
+    esp_panel::drivers::TouchPoint point;
+    int count = manager->touch_->readPoints(&point, 1, 0);
+    if (count > 0)
+    {
+        data->state = LV_INDEV_STATE_PR;
+        data->point.x = point.x;
+        data->point.y = point.y;
+    }
+    else
+    {
+        data->state = LV_INDEV_STATE_REL;
+    }
+}
+
+DisplayManager displayManager;
+
+#endif // ENABLE_DISPLAY

--- a/src/display/DisplayManager.h
+++ b/src/display/DisplayManager.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#ifdef ENABLE_DISPLAY
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#include <esp_timer.h>
+#include <vector>
+
+#include "DisplayUI.h"
+#include "WifiNetworkList.h"
+#include "WifiDeviceList.h"
+#include "BLEDeviceList.h"
+#include "AppPreferences.h"
+
+class DisplayManager
+{
+public:
+    DisplayManager();
+    void begin();
+    void loop();
+    void refresh(const WifiNetworkList &networks,
+                 const WifiDeviceList &stations,
+                 const BLEDeviceList &bleDevices,
+                 const AppPreferencesData &prefs,
+                 int currentChannel,
+                 bool detectionAlarm,
+                 const std::string &detectionTarget);
+
+    void setDeviceConnected(bool connected);
+
+private:
+    static constexpr uint32_t kTickPeriodMs = 5;
+    static constexpr uint32_t kRefreshIntervalMs = 1500;
+    static constexpr uint32_t kBufferLines = 60;
+
+    static void lvglTask(void *param);
+    static void tickCallback(void *param);
+    static void flushCallback(lv_display_t *disp, const lv_area_t *area, uint8_t *pxMap);
+    static void touchReadCallback(lv_indev_t *indev, lv_indev_data_t *data);
+
+    void updateUI(const DisplaySummaryInfo &summary,
+                  std::vector<WifiNetworkView> networks,
+                  std::vector<WifiDeviceView> stations,
+                  std::vector<BleDeviceView> bleDevices);
+
+    bool initialized_ = false;
+    bool deviceConnected_ = false;
+    uint32_t lastRefreshMs_ = 0;
+
+    esp_panel::board::Board board_;
+    esp_panel::drivers::LCD *lcd_ = nullptr;
+    esp_panel::drivers::Touch *touch_ = nullptr;
+    lv_display_t *display_ = nullptr;
+    lv_indev_t *inputDevice_ = nullptr;
+
+    lv_color_t *drawBuffer1_ = nullptr;
+    lv_color_t *drawBuffer2_ = nullptr;
+    size_t bufferSizeBytes_ = 0;
+
+    SemaphoreHandle_t mutex_ = nullptr;
+    TaskHandle_t taskHandle_ = nullptr;
+    esp_timer_handle_t tickTimer_ = nullptr;
+
+    DisplayUI ui_;
+};
+
+extern DisplayManager displayManager;
+
+#endif // ENABLE_DISPLAY

--- a/src/display/DisplayTypes.h
+++ b/src/display/DisplayTypes.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#ifdef ENABLE_DISPLAY
+
+#include <cstdint>
+#include <string>
+
+struct WifiNetworkView
+{
+    std::string ssid;
+    int rssi = 0;
+    int channel = 0;
+    std::string type;
+    uint32_t timesSeen = 0;
+};
+
+struct WifiDeviceView
+{
+    std::string mac;
+    int rssi = 0;
+    int channel = 0;
+    uint32_t timesSeen = 0;
+};
+
+struct BleDeviceView
+{
+    std::string name;
+    std::string address;
+    bool isPublic = false;
+    int rssi = 0;
+    uint32_t timesSeen = 0;
+};
+
+struct DisplaySummaryInfo
+{
+    size_t wifiNetworkCount = 0;
+    size_t wifiDeviceCount = 0;
+    size_t bleDeviceCount = 0;
+    uint8_t operationMode = 0;
+    bool passiveScan = false;
+    bool stealthMode = false;
+    bool detectionAlarm = false;
+    bool deviceConnected = false;
+    int currentChannel = -1;
+    std::string detectionTarget;
+    std::string deviceName;
+    uint32_t lastRefreshMillis = 0;
+};
+
+#endif // ENABLE_DISPLAY

--- a/src/display/DisplayUI.cpp
+++ b/src/display/DisplayUI.cpp
@@ -1,0 +1,430 @@
+#include "DisplayUI.h"
+
+#ifdef ENABLE_DISPLAY
+
+#include <algorithm>
+#include <cstdio>
+#include "AppPreferences.h"
+
+namespace
+{
+constexpr std::size_t kMaxTableRows = 8;
+
+lv_color_t badgeColorForMode(uint8_t mode)
+{
+    switch (mode)
+    {
+    case OPERATION_MODE_SCAN:
+        return lv_palette_main(LV_PALETTE_BLUE);
+    case OPERATION_MODE_DETECTION:
+        return lv_palette_main(LV_PALETTE_DEEP_ORANGE);
+    default:
+        return lv_palette_main(LV_PALETTE_GREY);
+    }
+}
+
+} // namespace
+
+void DisplayUI::create(const DisplaySummaryInfo &summary)
+{
+    if (created_)
+    {
+        return;
+    }
+
+    createLayout(summary);
+    created_ = true;
+}
+
+void DisplayUI::update(const DisplaySummaryInfo &summary,
+                       const std::vector<WifiNetworkView> &networks,
+                       const std::vector<WifiDeviceView> &stations,
+                       const std::vector<BleDeviceView> &bleDevices)
+{
+    if (!created_)
+    {
+        create(summary);
+    }
+
+    updateSummary(summary);
+    updateWifiTable(networks);
+    updateStationTable(stations);
+    updateBleTable(bleDevices);
+}
+
+void DisplayUI::createLayout(const DisplaySummaryInfo &summary)
+{
+    screen_ = lv_scr_act();
+    lv_obj_set_style_bg_color(screen_, lv_color_hex(0x0e141b), 0);
+    lv_obj_set_style_bg_grad_color(screen_, lv_color_hex(0x151d26), 0);
+    lv_obj_set_style_bg_grad_dir(screen_, LV_GRAD_DIR_VER, 0);
+
+    // Header with device name and mode badge
+    lv_obj_t *header = lv_obj_create(screen_);
+    lv_obj_remove_style_all(header);
+    lv_obj_set_width(header, LV_PCT(100));
+    lv_obj_set_style_pad_all(header, 20, 0);
+    lv_obj_set_style_pad_row(header, 12, 0);
+    lv_obj_set_layout(header, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(header, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(header, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+    deviceNameLabel_ = lv_label_create(header);
+    lv_obj_set_style_text_font(deviceNameLabel_, &lv_font_montserrat_28, 0);
+    lv_obj_set_style_text_color(deviceNameLabel_, lv_color_hex(0xffffff), 0);
+
+    modeBadge_ = lv_label_create(header);
+    lv_label_set_long_mode(modeBadge_, LV_LABEL_LONG_WRAP);
+    lv_obj_set_style_bg_color(modeBadge_, badgeColorForMode(summary.operationMode), 0);
+    lv_obj_set_style_bg_opa(modeBadge_, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(modeBadge_, 14, 0);
+    lv_obj_set_style_pad_hor(modeBadge_, 14, 0);
+    lv_obj_set_style_pad_ver(modeBadge_, 8, 0);
+    lv_obj_set_style_text_color(modeBadge_, lv_color_hex(0xFFFFFF), 0);
+    lv_obj_set_style_text_font(modeBadge_, &lv_font_montserrat_18, 0);
+
+    // Stats container
+    lv_obj_t *stats = lv_obj_create(screen_);
+    lv_obj_remove_style_all(stats);
+    lv_obj_set_width(stats, LV_PCT(100));
+    lv_obj_set_style_bg_color(stats, lv_color_hex(0x141c24), 0);
+    lv_obj_set_style_bg_opa(stats, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(stats, 18, 0);
+    lv_obj_set_style_pad_all(stats, 24, 0);
+    lv_obj_set_style_pad_column(stats, 32, 0);
+    lv_obj_set_style_pad_row(stats, 18, 0);
+    lv_obj_set_layout(stats, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(stats, LV_FLEX_FLOW_ROW_WRAP);
+    lv_obj_set_flex_align(stats, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+    wifiCountLabel_ = createStatCard(stats, "WiFi Networks", lv_palette_main(LV_PALETTE_LIGHT_BLUE));
+    stationCountLabel_ = createStatCard(stats, "WiFi Devices", lv_palette_main(LV_PALETTE_AMBER));
+    bleCountLabel_ = createStatCard(stats, "BLE Devices", lv_palette_main(LV_PALETTE_DEEP_PURPLE));
+
+    lastUpdateLabel_ = createStatCard(stats, "Last Refresh", lv_palette_main(LV_PALETTE_GREY));
+    channelLabel_ = createStatCard(stats, "Channel", lv_palette_main(LV_PALETTE_CYAN));
+    detectionLabel_ = createStatCard(stats, "Detection", lv_palette_main(LV_PALETTE_RED));
+
+    // Tables container
+    lv_obj_t *tables = lv_obj_create(screen_);
+    lv_obj_remove_style_all(tables);
+    lv_obj_set_width(tables, LV_PCT(100));
+    lv_obj_set_style_pad_all(tables, 0, 0);
+    lv_obj_set_style_pad_gap(tables, 20, 0);
+    lv_obj_set_layout(tables, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(tables, LV_FLEX_FLOW_ROW_WRAP);
+    lv_obj_set_flex_align(tables, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER);
+
+    wifiTable_ = createTableSection(tables, "WiFi Networks", 5);
+    lv_obj_set_width(lv_obj_get_parent(wifiTable_), LV_PCT(100));
+
+    stationTable_ = createTableSection(tables, "Stations", 4);
+    lv_obj_set_width(lv_obj_get_parent(stationTable_), LV_PCT(48));
+
+    bleTable_ = createTableSection(tables, "BLE Devices", 4);
+    lv_obj_set_width(lv_obj_get_parent(bleTable_), LV_PCT(48));
+
+    // Configure headers and column widths
+    configureTableHeader(wifiTable_, {"SSID", "RSSI", "Ch", "Type", "Seen"});
+    configureTableHeader(stationTable_, {"MAC", "RSSI", "Ch", "Seen"});
+    configureTableHeader(bleTable_, {"Device", "Public", "RSSI", "Seen"});
+
+    lv_table_set_column_width(wifiTable_, 0, 360);
+    lv_table_set_column_width(wifiTable_, 1, 90);
+    lv_table_set_column_width(wifiTable_, 2, 70);
+    lv_table_set_column_width(wifiTable_, 3, 140);
+    lv_table_set_column_width(wifiTable_, 4, 90);
+
+    lv_table_set_column_width(stationTable_, 0, 240);
+    lv_table_set_column_width(stationTable_, 1, 90);
+    lv_table_set_column_width(stationTable_, 2, 70);
+    lv_table_set_column_width(stationTable_, 3, 90);
+
+    lv_table_set_column_width(bleTable_, 0, 260);
+    lv_table_set_column_width(bleTable_, 1, 90);
+    lv_table_set_column_width(bleTable_, 2, 90);
+    lv_table_set_column_width(bleTable_, 3, 90);
+
+    updateSummary(summary);
+}
+
+void DisplayUI::updateSummary(const DisplaySummaryInfo &summary)
+{
+    std::string name = "Sneak32";
+    if (!summary.deviceName.empty())
+    {
+        name += " • " + summary.deviceName;
+    }
+    lv_label_set_text(deviceNameLabel_, name.c_str());
+
+    std::string modeText;
+    switch (summary.operationMode)
+    {
+    case OPERATION_MODE_SCAN:
+        modeText = "Scan";
+        break;
+    case OPERATION_MODE_DETECTION:
+        modeText = "Detection";
+        break;
+    default:
+        modeText = "Idle";
+        break;
+    }
+    if (summary.passiveScan)
+    {
+        modeText += " • Passive";
+    }
+    if (summary.stealthMode)
+    {
+        modeText += " • Stealth";
+    }
+    if (summary.deviceConnected)
+    {
+        modeText += " • BLE Link";
+    }
+    lv_label_set_text(modeBadge_, modeText.c_str());
+    lv_obj_set_style_bg_color(modeBadge_, badgeColorForMode(summary.operationMode), 0);
+
+    lv_label_set_text(wifiCountLabel_, formatCount(summary.wifiNetworkCount).c_str());
+    lv_label_set_text(stationCountLabel_, formatCount(summary.wifiDeviceCount).c_str());
+    lv_label_set_text(bleCountLabel_, formatCount(summary.bleDeviceCount).c_str());
+    lv_label_set_text(lastUpdateLabel_, formatDuration(summary.lastRefreshMillis).c_str());
+    lv_label_set_text(channelLabel_, formatChannel(summary.currentChannel).c_str());
+
+    std::string detection = "Standby";
+    if (summary.operationMode == OPERATION_MODE_DETECTION)
+    {
+        detection = summary.detectionTarget.empty() ? "Auto" : summary.detectionTarget;
+        if (summary.detectionAlarm)
+        {
+            detection += " • ALERT";
+            lv_obj_set_style_text_color(detectionLabel_, lv_palette_main(LV_PALETTE_RED), 0);
+        }
+        else
+        {
+            lv_obj_set_style_text_color(detectionLabel_, lv_color_hex(0xffffff), 0);
+        }
+    }
+    else
+    {
+        lv_obj_set_style_text_color(detectionLabel_, lv_color_hex(0xffffff), 0);
+    }
+    lv_label_set_text(detectionLabel_, detection.c_str());
+}
+
+void DisplayUI::updateWifiTable(const std::vector<WifiNetworkView> &networks)
+{
+    lv_table_set_row_cnt(wifiTable_, kMaxTableRows + 1);
+    for (std::size_t i = 0; i < kMaxTableRows; ++i)
+    {
+        if (i < networks.size())
+        {
+            const auto &item = networks[i];
+            lv_table_set_cell_value(wifiTable_, i + 1, 0, item.ssid.c_str());
+            lv_table_set_cell_value(wifiTable_, i + 1, 1, formatRssi(item.rssi).c_str());
+            lv_table_set_cell_value(wifiTable_, i + 1, 2, formatChannel(item.channel).c_str());
+            lv_table_set_cell_value(wifiTable_, i + 1, 3, item.type.c_str());
+            lv_table_set_cell_value(wifiTable_, i + 1, 4, formatTimes(item.timesSeen).c_str());
+        }
+        else
+        {
+            for (int col = 0; col < 5; ++col)
+            {
+                lv_table_set_cell_value(wifiTable_, i + 1, col, "");
+            }
+        }
+    }
+}
+
+void DisplayUI::updateStationTable(const std::vector<WifiDeviceView> &stations)
+{
+    lv_table_set_row_cnt(stationTable_, kMaxTableRows + 1);
+    for (std::size_t i = 0; i < kMaxTableRows; ++i)
+    {
+        if (i < stations.size())
+        {
+            const auto &item = stations[i];
+            lv_table_set_cell_value(stationTable_, i + 1, 0, item.mac.c_str());
+            lv_table_set_cell_value(stationTable_, i + 1, 1, formatRssi(item.rssi).c_str());
+            lv_table_set_cell_value(stationTable_, i + 1, 2, formatChannel(item.channel).c_str());
+            lv_table_set_cell_value(stationTable_, i + 1, 3, formatTimes(item.timesSeen).c_str());
+        }
+        else
+        {
+            for (int col = 0; col < 4; ++col)
+            {
+                lv_table_set_cell_value(stationTable_, i + 1, col, "");
+            }
+        }
+    }
+}
+
+void DisplayUI::updateBleTable(const std::vector<BleDeviceView> &devices)
+{
+    lv_table_set_row_cnt(bleTable_, kMaxTableRows + 1);
+    for (std::size_t i = 0; i < kMaxTableRows; ++i)
+    {
+        if (i < devices.size())
+        {
+            const auto &item = devices[i];
+            lv_table_set_cell_value(bleTable_, i + 1, 0, formatBleName(item).c_str());
+            lv_table_set_cell_value(bleTable_, i + 1, 1, item.isPublic ? "Yes" : "Random");
+            lv_table_set_cell_value(bleTable_, i + 1, 2, formatRssi(item.rssi).c_str());
+            lv_table_set_cell_value(bleTable_, i + 1, 3, formatTimes(item.timesSeen).c_str());
+        }
+        else
+        {
+            for (int col = 0; col < 4; ++col)
+            {
+                lv_table_set_cell_value(bleTable_, i + 1, col, "");
+            }
+        }
+    }
+}
+
+lv_obj_t *DisplayUI::createStatCard(lv_obj_t *parent, const char *title, lv_color_t accentColor)
+{
+    lv_obj_t *card = lv_obj_create(parent);
+    lv_obj_remove_style_all(card);
+    lv_obj_set_style_bg_color(card, lv_color_hex(0x1b252f), 0);
+    lv_obj_set_style_bg_opa(card, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(card, 16, 0);
+    lv_obj_set_style_pad_hor(card, 20, 0);
+    lv_obj_set_style_pad_ver(card, 16, 0);
+    lv_obj_set_style_pad_row(card, 10, 0);
+    lv_obj_set_layout(card, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(card, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(card, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+    lv_obj_t *caption = lv_label_create(card);
+    lv_obj_set_style_text_color(caption, accentColor, 0);
+    lv_obj_set_style_text_font(caption, &lv_font_montserrat_16, 0);
+    lv_label_set_text(caption, title);
+
+    lv_obj_t *value = lv_label_create(card);
+    lv_obj_set_style_text_color(value, lv_color_hex(0xFFFFFF), 0);
+    lv_obj_set_style_text_font(value, &lv_font_montserrat_28, 0);
+    lv_label_set_text(value, "--");
+    return value;
+}
+
+lv_obj_t *DisplayUI::createTableSection(lv_obj_t *parent, const char *title, uint8_t columnCount)
+{
+    lv_obj_t *section = lv_obj_create(parent);
+    lv_obj_remove_style_all(section);
+    lv_obj_set_style_bg_color(section, lv_color_hex(0x141c24), 0);
+    lv_obj_set_style_bg_opa(section, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(section, 18, 0);
+    lv_obj_set_style_pad_all(section, 24, 0);
+    lv_obj_set_style_pad_row(section, 16, 0);
+    lv_obj_set_layout(section, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(section, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(section, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER);
+
+    lv_obj_t *titleLabel = lv_label_create(section);
+    lv_obj_set_style_text_font(titleLabel, &lv_font_montserrat_20, 0);
+    lv_obj_set_style_text_color(titleLabel, lv_color_hex(0xffffff), 0);
+    lv_label_set_text(titleLabel, title);
+
+    lv_obj_t *table = lv_table_create(section);
+    lv_obj_set_width(table, LV_PCT(100));
+    lv_obj_set_style_bg_opa(table, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(table, 1, 0);
+    lv_obj_set_style_border_color(table, lv_color_hex(0x1f2a33), 0);
+    lv_obj_set_style_pad_all(table, 0, 0);
+    lv_table_set_column_cnt(table, columnCount);
+    lv_obj_set_style_text_font(table, &lv_font_montserrat_16, 0);
+    return table;
+}
+
+void DisplayUI::configureTableHeader(lv_obj_t *table, const std::vector<std::string> &headers)
+{
+    lv_table_set_row_cnt(table, 1);
+    for (std::size_t i = 0; i < headers.size(); ++i)
+    {
+        lv_table_set_cell_value(table, 0, static_cast<int>(i), headers[i].c_str());
+        lv_table_set_cell_align(table, 0, static_cast<int>(i), LV_TEXT_ALIGN_LEFT);
+    }
+    lv_obj_set_style_text_color(table, lv_color_hex(0xffffff), 0);
+}
+
+std::string DisplayUI::formatCount(size_t value)
+{
+    char buffer[16];
+    if (value >= 1'000'000)
+    {
+        std::snprintf(buffer, sizeof(buffer), "%.1fM", value / 1'000'000.0);
+    }
+    else if (value >= 1'000)
+    {
+        std::snprintf(buffer, sizeof(buffer), "%.1fk", value / 1'000.0);
+    }
+    else
+    {
+        std::snprintf(buffer, sizeof(buffer), "%u", static_cast<unsigned>(value));
+    }
+    return buffer;
+}
+
+std::string DisplayUI::formatRssi(int rssi)
+{
+    char buffer[16];
+    if (rssi == 0)
+    {
+        return "--";
+    }
+    std::snprintf(buffer, sizeof(buffer), "%d dBm", rssi);
+    return buffer;
+}
+
+std::string DisplayUI::formatTimes(uint32_t times)
+{
+    char buffer[16];
+    std::snprintf(buffer, sizeof(buffer), "%u", static_cast<unsigned>(times));
+    return buffer;
+}
+
+std::string DisplayUI::formatChannel(int channel)
+{
+    if (channel <= 0)
+    {
+        return "--";
+    }
+    char buffer[8];
+    std::snprintf(buffer, sizeof(buffer), "%d", channel);
+    return buffer;
+}
+
+std::string DisplayUI::formatDuration(uint32_t millis)
+{
+    uint32_t seconds = millis / 1000U;
+    uint32_t hours = seconds / 3600U;
+    uint32_t minutes = (seconds % 3600U) / 60U;
+    uint32_t secs = seconds % 60U;
+
+    char buffer[32];
+    if (hours > 0)
+    {
+        std::snprintf(buffer, sizeof(buffer), "%02u:%02u:%02u", hours, minutes, secs);
+    }
+    else
+    {
+        std::snprintf(buffer, sizeof(buffer), "%02u:%02u", minutes, secs);
+    }
+    return buffer;
+}
+
+std::string DisplayUI::formatBleName(const BleDeviceView &device)
+{
+    if (!device.name.empty())
+    {
+        return device.name;
+    }
+    if (!device.address.empty())
+    {
+        return device.address;
+    }
+    return "Unknown";
+}
+
+#endif // ENABLE_DISPLAY

--- a/src/display/DisplayUI.h
+++ b/src/display/DisplayUI.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#ifdef ENABLE_DISPLAY
+
+#include <vector>
+#include <string>
+#include <lvgl.h>
+
+#include "DisplayTypes.h"
+
+class DisplayUI
+{
+public:
+    DisplayUI() = default;
+    void create(const DisplaySummaryInfo &summary);
+    void update(const DisplaySummaryInfo &summary,
+                const std::vector<WifiNetworkView> &networks,
+                const std::vector<WifiDeviceView> &stations,
+                const std::vector<BleDeviceView> &bleDevices);
+
+private:
+    void createLayout(const DisplaySummaryInfo &summary);
+    void updateSummary(const DisplaySummaryInfo &summary);
+    void updateWifiTable(const std::vector<WifiNetworkView> &networks);
+    void updateStationTable(const std::vector<WifiDeviceView> &stations);
+    void updateBleTable(const std::vector<BleDeviceView> &devices);
+
+    lv_obj_t *createStatCard(lv_obj_t *parent, const char *title, lv_color_t accentColor);
+    lv_obj_t *createTableSection(lv_obj_t *parent, const char *title, uint8_t columnCount);
+    void configureTableHeader(lv_obj_t *table, const std::vector<std::string> &headers);
+
+    static std::string formatCount(size_t value);
+    static std::string formatRssi(int rssi);
+    static std::string formatTimes(uint32_t times);
+    static std::string formatChannel(int channel);
+    static std::string formatDuration(uint32_t millis);
+    static std::string formatBleName(const BleDeviceView &device);
+
+    bool created_ = false;
+    lv_obj_t *screen_ = nullptr;
+    lv_obj_t *modeBadge_ = nullptr;
+    lv_obj_t *deviceNameLabel_ = nullptr;
+    lv_obj_t *wifiCountLabel_ = nullptr;
+    lv_obj_t *stationCountLabel_ = nullptr;
+    lv_obj_t *bleCountLabel_ = nullptr;
+    lv_obj_t *lastUpdateLabel_ = nullptr;
+    lv_obj_t *channelLabel_ = nullptr;
+    lv_obj_t *detectionLabel_ = nullptr;
+    lv_obj_t *wifiTable_ = nullptr;
+    lv_obj_t *stationTable_ = nullptr;
+    lv_obj_t *bleTable_ = nullptr;
+};
+
+#endif // ENABLE_DISPLAY

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,6 +68,9 @@
 #include "BLEAdvertisingManager.h"
 #include "FirmwareInfo.h"
 #include "BLEStatusUpdater.h"
+#ifdef ENABLE_DISPLAY
+#include "display/DisplayManager.h"
+#endif
 
 // Define the boot button pin (adjust if necessary)
 #define BOOT_BUTTON_PIN 0
@@ -299,6 +302,11 @@ void setup()
   pinMode(BOOT_BUTTON_PIN, INPUT_PULLUP);
 
   esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_DEFAULT, ESP_PWR_LVL_P9);
+
+#ifdef ENABLE_DISPLAY
+  displayManager.begin();
+  displayManager.refresh(ssidList, stationsList, bleDeviceList, appPrefs, 0, false, "");
+#endif
 }
 
 /**
@@ -317,6 +325,10 @@ void scan_mode_loop()
 
   Serial.printf(">> Time: %lu, WiFi Ch: %2d, SSIDs: %zu, Stations: %zu, BLE: %zu, Heap: %d\n",
                 millis() / 1000, currentChannel, ssidList.size(), stationsList.size(), bleDeviceList.size(), ESP.getFreeHeap());
+
+#ifdef ENABLE_DISPLAY
+  displayManager.refresh(ssidList, stationsList, bleDeviceList, appPrefs, currentChannel, false, "");
+#endif
 
   delay(appPrefs.wifi_channel_dwell_time);
 
@@ -373,10 +385,14 @@ void detection_mode_loop()
   static auto clonedList = ssidList.getClonedList();
   static size_t currentSSIDIndex = 0;
 
+  std::string detectionTarget;
+  bool detectionAlarm = WifiDetector.isSomethingDetected();
+
   if (appPrefs.passive_scan)
   {
     WifiDetector.setChannel(1);
     Serial.println(">> Passive WiFi scan");
+    detectionTarget = "Passive";
   }
   else
   {
@@ -386,17 +402,20 @@ void detection_mode_loop()
     }
 
     const auto &currentNetwork = clonedList[currentSSIDIndex];
-    // Configure ESP32 to broadcast the selected SSID
-    // WifiDetector.setupAP(currentNetwork.ssid.c_str(), nullptr, 1);
     if (&currentNetwork && currentNetwork.ssid && currentNetwork.ssid.length() > 0) {
       WifiDetector.setupAP(currentNetwork.ssid.c_str(), nullptr, 1);
       Serial.printf(">> Detection Mode (%02d/%02d) >> Alarm: %d, Broadcasting SSID: \"%s\", Last detection: %d\n",
-                    currentSSIDIndex + 1, clonedList.size(), WifiDetector.isSomethingDetected(), currentNetwork.ssid.c_str(),
+                    currentSSIDIndex + 1, clonedList.size(), detectionAlarm, currentNetwork.ssid.c_str(),
                     millis() / 1000 - WifiDetector.getLastDetectionTime());
+      detectionTarget = currentNetwork.ssid.c_str();
     }
 
     currentSSIDIndex++;
   }
+
+#ifdef ENABLE_DISPLAY
+  displayManager.refresh(ssidList, stationsList, bleDeviceList, appPrefs, 1, detectionAlarm, detectionTarget);
+#endif
 
   checkTransmissionTimeout();
   checkAndRestartAdvertising();
@@ -412,6 +431,10 @@ void detection_mode_loop()
  */
 void loop()
 {
+#ifdef ENABLE_DISPLAY
+  displayManager.setDeviceConnected(deviceConnected);
+#endif
+
   if (appPrefs.operation_mode == OPERATION_MODE_SCAN)
   {
     scan_mode_loop();


### PR DESCRIPTION
## Summary
- add an LVGL-based dashboard that renders Sneak32 WiFi/BLE activity on supported LCD panels
- integrate the display manager with the scanning and detection loops so the UI stays in sync with device status
- document the new Waveshare ESP32-S3 Touch LCD target and provide a dedicated PlatformIO environment

## Testing
- `~/.local/bin/platformio run --verbose -e waveshare-esp32-s3-touch-lcd-5b` *(fails: HTTPClientError while fetching espressif32 platform)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ff973c8c832c96be5823553b89a6

## Summary by Sourcery

Enable LVGL-powered dashboard support for Waveshare ESP32-S3 Touch LCD by adding DisplayManager and DisplayUI components, integrating display updates into the main application loops, and supplying a dedicated PlatformIO environment with documentation.

New Features:
- Introduce LVGL-based dashboard modules (DisplayManager and DisplayUI) to visualize live WiFi and BLE activity on supported LCD panels
- Add a dedicated PlatformIO environment for the Waveshare ESP32-S3 Touch LCD with LVGL and display panel library dependencies

Enhancements:
- Integrate display initialization and periodic UI refresh calls into setup, scan, and detection loops under the ENABLE_DISPLAY flag

Build:
- Add LVGL configuration header (lv_conf.h) and update platformio.ini with build flags and library dependencies for LVGL and display panel support

Documentation:
- Update README to document the optional LVGL dashboard feature and list the Waveshare ESP32-S3 Touch LCD as a supported target